### PR TITLE
fix - menu window not getting opened in linux

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,7 +8,9 @@ use tauri_plugin_positioner::{Position, WindowExt};
 
 fn main() {
     let quit = CustomMenuItem::new("quit".to_string(), "Quit").accelerator("Cmd+Q");
-    let system_tray_menu = SystemTrayMenu::new().add_item(quit);
+    let open = CustomMenuItem::new("open".to_string(), "Open");
+
+    let system_tray_menu = SystemTrayMenu::new().add_item(open).add_item(quit);
     tauri::Builder::default()
         .plugin(tauri_plugin_positioner::init())
         .system_tray(SystemTray::new().with_menu(system_tray_menu))
@@ -45,6 +47,12 @@ fn main() {
                     println!("system tray received a double click");
                 }
                 SystemTrayEvent::MenuItemClick { id, .. } => match id.as_str() {
+                    "open" => {
+                        let window = app.get_window("main").unwrap();
+                        // let _ = window.move_window(Position::TrayCenter);
+                        window.show().unwrap();
+                        window.set_focus().unwrap();
+                    }
                     "quit" => {
                         std::process::exit(0);
                     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,14 +3,22 @@
     windows_subsystem = "windows"
 )]
 
+
+use std::env;
 use tauri::{CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu};
 use tauri_plugin_positioner::{Position, WindowExt};
 
 fn main() {
-    let quit = CustomMenuItem::new("quit".to_string(), "Quit").accelerator("Cmd+Q");
-    let open = CustomMenuItem::new("open".to_string(), "Open");
+    let mut system_tray_menu = SystemTrayMenu::new();
 
-    let system_tray_menu = SystemTrayMenu::new().add_item(open).add_item(quit);
+    if cfg!(target_os = "linux") {
+        let open = CustomMenuItem::new("open".to_string(), "Open").accelerator("Cmd+H");
+        system_tray_menu = system_tray_menu.clone().add_item(open);
+    }
+
+    let quit = CustomMenuItem::new("quit".to_string(), "Quit").accelerator("Cmd+Q");
+    system_tray_menu = system_tray_menu.clone().add_item(quit);
+
     tauri::Builder::default()
         .plugin(tauri_plugin_positioner::init())
         .system_tray(SystemTray::new().with_menu(system_tray_menu))
@@ -49,7 +57,6 @@ fn main() {
                 SystemTrayEvent::MenuItemClick { id, .. } => match id.as_str() {
                     "open" => {
                         let window = app.get_window("main").unwrap();
-                        // let _ = window.move_window(Position::TrayCenter);
                         window.show().unwrap();
                         window.set_focus().unwrap();
                     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,7 @@ fn main() {
     let mut system_tray_menu = SystemTrayMenu::new();
 
     if cfg!(target_os = "linux") {
-        let open = CustomMenuItem::new("open".to_string(), "Open").accelerator("Cmd+H");
+        let open = CustomMenuItem::new("open".to_string(), "Open");
         system_tray_menu = system_tray_menu.clone().add_item(open);
     }
 


### PR DESCRIPTION
Since linux doesn't support click events on SysTray except `SystemTrayEvent::MenuItemClick`, added menu item `Open` to trigger application window.
 

![image](https://github.com/fayazara/hawa/assets/22255990/3ba8ae92-c028-458c-90e6-a02dc0ac4d15)
