### PR TITLE
fix: adds windows support and dialog box orientation fix

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,7 +3,6 @@
     windows_subsystem = "windows"
 )]
 
-
 use std::env;
 use tauri::{CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu};
 use tauri_plugin_positioner::{Position, WindowExt};

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,6 +37,7 @@
 <script setup>
 import { inject } from "vue";
 import { exit } from "@tauri-apps/api/process";
+import { platform } from '@tauri-apps/api/os';
 import Icon from "./components/Icon.vue";
 import GithubIcon from "./components/GithubIcon.vue";
 import Player from "./components/Player.vue";
@@ -86,4 +87,13 @@ const exitApp = async () => {
 const stopAll = () => {
   emitter.emit("stopAll");
 };
+
+const setupOs = async () => {
+  const platformName = await platform();
+  if (platformName) {
+    document.body.classList.add(platformName);
+  }
+};
+
+setupOs();
 </script>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,9 +3,18 @@
 @tailwind utilities;
 
 .arrow:before {
-  content: "";
-  @apply h-0 w-0  absolute top-0 left-1/2 -translate-x-1/2;
-  border-width: 0 8px 8px 8px;
-  border-style: solid;
-  border-color: transparent transparent #fff transparent;
+	content: "";
+	@apply h-0 w-0  absolute top-0 left-1/2 -translate-x-1/2;
+	border-width: 0 8px 8px 8px;
+	border-style: solid;
+	border-color: transparent transparent #fff transparent;
+}
+
+.win32.arrow:before {
+	top: unset;
+	@apply bottom-0 rotate-180 bottom-0;
+}
+
+body.win32 {
+	@apply pt-0 pb-2;
 }


### PR DESCRIPTION
Since on Windows, the taskbar is (usually) at the bottom of the screen instead of elsewhere. We need to slightly adjust the margin, padding and direction of the triangle to match the system better!

![Screenshot 2023-10-18 010639](https://github.com/fayazara/hawa/assets/30227512/f1123600-600e-49af-80c8-9c63978c4a54)
